### PR TITLE
Create prescribed shear heating output

### DIFF
--- a/include/aspect/heating_model/shear_heating.h
+++ b/include/aspect/heating_model/shear_heating.h
@@ -95,6 +95,9 @@ namespace aspect
      * Additional output fields for the shear heating computation
      * to be added to the MaterialModel::MaterialModelOutputs structure
      * and filled in the MaterialModel::evaluate() function.
+     *
+     * This structure allows to modify the shear heating term by
+     * multiplying it with a factor computed by the material model.
      */
     template <int dim>
     class ShearHeatingOutputs : public MaterialModel::NamedAdditionalMaterialOutputs<dim>
@@ -111,6 +114,31 @@ namespace aspect
          * work will go into shear heating.
          */
         std::vector<double> shear_heating_work_fractions;
+    };
+
+    /**
+     * Additional output fields for the shear heating computation
+     * to be added to the MaterialModel::MaterialModelOutputs structure
+     * and filled in the MaterialModel::evaluate() function.
+     *
+     * This structure allows to prescribe the full shear heating term from
+     * the material model.
+     */
+    template <int dim>
+    class PrescribedShearHeatingOutputs : public MaterialModel::NamedAdditionalMaterialOutputs<dim>
+    {
+      public:
+        PrescribedShearHeatingOutputs(const unsigned int n_points);
+
+        std::vector<double> get_nth_output(const unsigned int idx) const override;
+
+        /**
+         * The viscous dissipation rate due to shear heating.
+         * If this object is created and filled by the material model
+         * it will replace the default viscous dissipation rate
+         * computed by the shear heating model.
+        */
+        std::vector<double> prescribed_shear_heating_rates;
     };
   }
 }

--- a/include/aspect/material_model/interface.h
+++ b/include/aspect/material_model/interface.h
@@ -1167,8 +1167,7 @@ namespace aspect
       public:
         ElasticOutputs(const unsigned int n_points)
           : elastic_force(n_points, numbers::signaling_nan<SymmetricTensor<2,dim>>()),
-            viscoelastic_strain_rate(n_points, numbers::signaling_nan<SymmetricTensor<2,dim>>()),
-            viscous_dissipation(n_points, numbers::signaling_nan<double>())
+            viscoelastic_strain_rate(n_points, numbers::signaling_nan<SymmetricTensor<2,dim>>())
         {}
 
         ~ElasticOutputs() override
@@ -1194,12 +1193,6 @@ namespace aspect
          * required by the Newton solver.
          */
         std::vector<SymmetricTensor<2,dim>> viscoelastic_strain_rate;
-
-        /**
-         * The viscous dissipation computed with the viscoplastic strain rate instead of the
-         * full strain rate.
-         */
-        std::vector<double> viscous_dissipation;
     };
 
 

--- a/source/material_model/rheology/elasticity.cc
+++ b/source/material_model/rheology/elasticity.cc
@@ -21,12 +21,13 @@
 
 #include <aspect/material_model/rheology/elasticity.h>
 
-#include <deal.II/base/signaling_nan.h>
-#include <deal.II/base/parameter_handler.h>
 #include <aspect/utilities.h>
 #include <aspect/material_model/visco_plastic.h>
 #include <aspect/material_model/viscoelastic.h>
+#include <aspect/heating_model/shear_heating.h>
 
+#include <deal.II/base/signaling_nan.h>
+#include <deal.II/base/parameter_handler.h>
 #include <deal.II/base/quadrature_lib.h>
 
 
@@ -317,6 +318,14 @@ namespace aspect
               std::make_unique<ElasticAdditionalOutputs<dim>> (n_points));
           }
 
+        // We need to modify the shear heating outputs to correctly account for elastic stresses.
+        if (out.template get_additional_output<HeatingModel::PrescribedShearHeatingOutputs<dim>>() == nullptr)
+          {
+            const unsigned int n_points = out.n_evaluation_points();
+            out.additional_outputs.push_back(
+              std::make_unique<HeatingModel::PrescribedShearHeatingOutputs<dim>> (n_points));
+          }
+
         // Create the ReactionRateOutputs that are necessary for the operator splitting
         // step (either on the fields or directly on the particles)
         // that sets both sets of stresses to the total stress of the
@@ -373,6 +382,12 @@ namespace aspect
 
         if (elastic_out == nullptr)
           return;
+
+        HeatingModel::PrescribedShearHeatingOutputs<dim>
+        *heating_out = out.template get_additional_output<HeatingModel::PrescribedShearHeatingOutputs<dim>>();
+
+        AssertThrow(heating_out != nullptr,
+                    ExcMessage("The heating model outputs are required for the elastic outputs."));
 
         if (in.requests_property(MaterialProperties::additional_outputs))
           {
@@ -466,7 +481,9 @@ namespace aspect
                 //                             1. / 3. * trace(visco_plastic_strain_rate) * unit_symmetric_tensor<dim>();
                 const SymmetricTensor<2, dim> visco_plastic_strain_rate = deviatoric_strain_rate - ((stress - stress_0_advected) / (2. * dtc * average_elastic_shear_moduli[i]));
 
-                elastic_out->viscous_dissipation[i] = stress * visco_plastic_strain_rate;
+                // The shear heating term needs to account for the elastic stress, but only the visco_plastic strain rate.
+                // This is best computed here, and stored for later use by the heating model.
+                heating_out->prescribed_shear_heating_rates[i] = stress * visco_plastic_strain_rate;
               }
 
           }


### PR DESCRIPTION
@anne-glerum this is a suggestion for how to deal with the special heating terms for the shear heating plugin. I would prefer if the terms could be its own material model outputs object. This way they are more flexible (other material models could use them as well), and they are not thrown together with the other elastic outputs, which are essentially unrelated. Does this make sense?