### PR TITLE
Operator splitting in nonlinear solver

### DIFF
--- a/include/aspect/particle/property/elastic_stress.h
+++ b/include/aspect/particle/property/elastic_stress.h
@@ -51,14 +51,6 @@ namespace aspect
           void initialize () override;
 
           /**
-           * Function to update the stresses on the particles after the
-           * nonlinear solver, similar to the operator split for stresses
-           * carried on fields.
-           */
-          void
-          update_particles (typename Particle::Manager<dim> &particle_manager) const;
-
-          /**
            * @copydoc aspect::Particle::Property::Interface::initialize_one_particle_property()
            */
           void
@@ -104,6 +96,14 @@ namespace aspect
           parse_parameters (ParameterHandler &prm) override;
 
         private:
+          /**
+           * Function to update the stresses on the particles, after
+           * the usual update has been carried out. Similar
+           * to the operator split for stresses carried on fields.
+           */
+          void
+          update_particles (typename Particle::Manager<dim> &particle_manager) const;
+
           /**
            * Objects that are used to compute the particle property. Since the
            * object is expensive to create and is needed often it is kept as a

--- a/include/aspect/simulator_signals.h
+++ b/include/aspect/simulator_signals.h
@@ -331,6 +331,13 @@ namespace aspect
      */
     boost::signals2::signal<void (Particle::Manager<dim> &)> post_restore_particles;
 
+    /**
+     * A signal that is triggered after particle properties have been updated, but before
+     * they have been interpolated to compositional fields. This happens
+     * in each iteration of iterative advection schemes.
+     * Parameters are a reference to a ParticleManager.
+     */
+    boost::signals2::signal<void (Particle::Manager<dim> &)> post_update_particles;
 
     /**
      * A signal that is triggered after particles have been restored to their position

--- a/include/aspect/simulator_signals.h
+++ b/include/aspect/simulator_signals.h
@@ -332,14 +332,6 @@ namespace aspect
     boost::signals2::signal<void (Particle::Manager<dim> &)> post_restore_particles;
 
     /**
-     * A signal that is triggered after particle properties have been updated, but before
-     * they have been interpolated to compositional fields. This happens
-     * in each iteration of iterative advection schemes.
-     * Parameters are a reference to a ParticleManager.
-     */
-    boost::signals2::signal<void (Particle::Manager<dim> &)> post_update_particles;
-
-    /**
      * A signal that is triggered after particles have been restored to their position
      * and property values from the beginning of the current timestep. This happens
      * at the beginning of each nonlinear iteration (except for the first iteration of the timestep)

--- a/source/particle/manager.cc
+++ b/source/particle/manager.cc
@@ -923,7 +923,6 @@ namespace aspect
 
               }
 
-          this->get_signals().post_update_particles(*this);
           this->get_computing_timer().leave_subsection("Particles: Update properties");
         }
     }

--- a/source/particle/manager.cc
+++ b/source/particle/manager.cc
@@ -923,6 +923,7 @@ namespace aspect
 
               }
 
+          this->get_signals().post_update_particles(*this);
           this->get_computing_timer().leave_subsection("Particles: Update properties");
         }
     }

--- a/source/particle/property/elastic_stress.cc
+++ b/source/particle/property/elastic_stress.cc
@@ -77,7 +77,7 @@ namespace aspect
 
         // Connect to the signal after the nonlinear solver to apply
         // the stress update of the current time step.
-        this->get_signals().post_nonlinear_solver_loop.connect(
+        this->get_signals().post_update_particles.connect(
           [&](typename Particle::Manager<dim> &particle_manager)
         {
           this->update_particles(particle_manager);

--- a/source/particle/property/elastic_stress.cc
+++ b/source/particle/property/elastic_stress.cc
@@ -61,7 +61,10 @@ namespace aspect
 
         material_outputs = MaterialModel::MaterialModelOutputs<dim>(1, this->n_compositional_fields());
 
-        material_inputs.requested_properties = MaterialModel::MaterialProperties::reaction_terms;
+        material_inputs.requested_properties = MaterialModel::MaterialProperties::reaction_terms | MaterialModel::MaterialProperties::reaction_rates;
+
+        // The reaction rates are stored in additional outputs
+        this->get_material_model().create_additional_named_outputs(material_outputs);
 
         // Get the indices of those compositions that correspond to stress tensor elements.
         stress_field_indices = this->introspection().get_indices_for_fields_of_type(CompositionalFieldDescription::stress);
@@ -74,184 +77,6 @@ namespace aspect
         std::set_difference(all_field_indices.begin(), all_field_indices.end(),
                             stress_field_indices.begin(), stress_field_indices.end(),
                             std::inserter(non_stress_field_indices, non_stress_field_indices.begin()));
-
-        // Connect to the signal after the nonlinear solver to apply
-        // the stress update of the current time step.
-        this->get_signals().post_update_particles.connect(
-          [&](typename Particle::Manager<dim> &particle_manager)
-        {
-          this->update_particles(particle_manager);
-        }
-        );
-      }
-
-
-      template <int dim>
-      void
-      ElasticStress<dim>::update_particles(typename Particle::Manager<dim> &particle_manager) const
-      {
-        // There is no update of the stress to apply during the first (0th) timestep
-        if (this->simulator_is_past_initialization() == false || this->get_timestep_number() == 0)
-          return;
-
-        // Determine the data position of the first stress tensor component
-        const unsigned int data_position = particle_manager.get_property_manager().get_data_info().get_position_by_field_name("ve_stress_xx");
-
-        // Get handler
-        Particle::ParticleHandler<dim> &particle_handler = particle_manager.get_particle_handler();
-
-        // TODO instead of calling the manager, and looping over all properties,
-        // can we use this property's get_update_flags() function only?
-        const std::vector<UpdateFlags> update_flags = particle_manager.get_property_manager().get_update_flags();
-
-        // combine all update flags to a single flag, which is the required information
-        // for the mapping inside the solution evaluator
-        UpdateFlags mapping_flags = update_flags[0];
-        for (unsigned int i=1; i<update_flags.size(); ++i)
-          mapping_flags |= update_flags[i];
-
-        // Create evaluators that get the old solution (= solution of previous timestep)
-        // at the locations of the particles within one cell.
-        // The particles have not been advected in the current timestep yet, or have been restored
-        // to their pre-advection locations, so they are in their old locations corresponding to the old
-        // solution.
-        std::unique_ptr<SolutionEvaluator<dim>> evaluators = construct_solution_evaluator(*this,
-                                                              mapping_flags);
-
-        // FEPointEvaluation uses different evaluation flags than the common UpdateFlags.
-        // Translate between the two.
-        std::vector<EvaluationFlags::EvaluationFlags> evaluation_flags (update_flags.size(), EvaluationFlags::nothing);
-
-        for (unsigned int i=0; i<update_flags.size(); ++i)
-          {
-            if (update_flags[i] & update_values)
-              evaluation_flags[i] |= EvaluationFlags::values;
-
-            if (update_flags[i] & update_gradients)
-              evaluation_flags[i] |= EvaluationFlags::gradients;
-          }
-
-        // Vector to store the positions of all the particles in one cell
-        small_vector<Point<dim>> positions;
-
-        // Loop over all active and owned cells
-        for (const auto &cell : this->get_dof_handler().active_cell_iterators())
-          if (cell->is_locally_owned())
-            {
-              // Find which particles are in the current cell
-              typename ParticleHandler<dim>::particle_iterator_range
-              particles_in_cell = particle_handler.particles_in_cell(cell);
-
-              // Only update particles, if there are any in this cell
-              if (particles_in_cell.begin() != particles_in_cell.end())
-                {
-                  const unsigned int n_particles_in_cell = particle_handler.n_particles_in_cell(cell);
-                  // Get the locations of the particles within the reference cell
-                  positions.resize(n_particles_in_cell);
-                  unsigned int p = 0;
-                  for (const auto &particle : particles_in_cell)
-                    {
-                      positions[p] = particle.get_reference_location();
-                      ++p;
-                    }
-
-                  // Resize the material model inputs to the number of particles in the current cell
-                  material_inputs_cell  = MaterialModel::MaterialModelInputs<dim>(n_particles_in_cell, this->n_compositional_fields());
-                  material_inputs_cell.current_cell = cell;
-                  material_inputs_cell.requested_properties = MaterialModel::MaterialProperties::reaction_rates;
-                  material_outputs_cell = MaterialModel::MaterialModelOutputs<dim>(n_particles_in_cell, this->n_compositional_fields());
-                  // The reaction rates are stored in additional outputs
-                  this->get_material_model().create_additional_named_outputs(material_outputs_cell);
-
-                  const std::shared_ptr<MaterialModel::ReactionRateOutputs<dim>> reaction_rate_outputs
-                    = material_outputs_cell.template get_additional_output_object<MaterialModel::ReactionRateOutputs<dim>>();
-
-                  // Collect the values of the solution restricted to the current cell's DOFs
-                  small_vector<double> solution_values(this->get_fe().dofs_per_cell);
-                  cell->get_dof_values(this->get_solution(),
-                                       solution_values.begin(),
-                                       solution_values.end());
-
-                  EvaluationFlags::EvaluationFlags evaluation_flags_union = EvaluationFlags::nothing;
-                  for (const auto flag : evaluation_flags)
-                    evaluation_flags_union |= flag;
-
-                  // Update evaluators to the current cell
-                  if (evaluation_flags_union & (EvaluationFlags::values | EvaluationFlags::gradients))
-                    {
-                      // Reinitialize and evaluate the requested solution values and gradients
-                      evaluators->reinit(cell, {positions.data(), positions.size()});
-
-                      evaluators->evaluate({solution_values.data(),solution_values.size()},
-                                           evaluation_flags);
-                    }
-
-                  // To store the old solutions
-                  std::vector<small_vector<double,50>> solution(n_particles_in_cell,small_vector<double,50>(evaluators->n_components(), numbers::signaling_nan<double>()));
-
-                  // To store the old gradients
-                  std::vector<small_vector<Tensor<1,dim>,50>> gradients(n_particles_in_cell,small_vector<Tensor<1,dim>,50>(evaluators->n_components(), numbers::signaling_nan<Tensor<1,dim>>()));
-
-                  // Loop over all particles in the cell
-                  auto particle = particles_in_cell.begin();
-                  for (unsigned int i = 0; particle!=particles_in_cell.end(); ++particle,++i)
-                    {
-                      // Evaluate the old solution, but only if it is requested in the update_flags
-                      if (evaluation_flags_union & EvaluationFlags::values)
-                        evaluators->get_solution(i, {&solution[i][0],solution[i].size()}, evaluation_flags);
-
-                      // Evaluate the old gradients, but only if they are requested in the update_flags
-                      if (evaluation_flags_union & EvaluationFlags::gradients)
-                        evaluators->get_gradients(i, {&gradients[i][0],gradients[i].size()}, evaluation_flags);
-
-                      // Fill material model input
-                      // Get the real location of the particle
-                      material_inputs_cell.position[i] = particle->get_location();
-
-                      material_inputs_cell.temperature[i] = solution[i][this->introspection().component_indices.temperature];
-
-                      material_inputs_cell.pressure[i] = solution[i][this->introspection().component_indices.pressure];
-
-                      for (unsigned int d = 0; d < dim; ++d)
-                        material_inputs_cell.velocity[i][d] = solution[i][this->introspection().component_indices.velocities[d]];
-
-                      // Fill the non-stress composition inputs with the current solution.
-                      for (const unsigned int &n : non_stress_field_indices)
-                        material_inputs_cell.composition[i][n] = solution[i][this->introspection().component_indices.compositional_fields[n]];
-
-                      // Retrieve the ve_stress_* values from the particles and fields and
-                      // fill the material model inputs with a weighted average of the two.
-                      // In some cases, using the field value leads to more stable results.
-                      // After the particles have been restored, their properties have the values of the previous timestep.
-                      for (unsigned int n = 0; n < 2*SymmetricTensor<2,dim>::n_independent_components; ++n)
-                        {
-                          const double particle_stress_value = particle->get_properties()[data_position + n];
-                          const double field_stress_value = solution[i][this->introspection().component_indices.compositional_fields[stress_field_indices[n]]];
-                          const double stress_value = particle_weight * particle_stress_value + (1-particle_weight) * field_stress_value;
-                          material_inputs_cell.composition[i][stress_field_indices[n]] = stress_value;
-                        }
-
-                      Tensor<2,dim> grad_u;
-                      for (unsigned int d=0; d<dim; ++d)
-                        grad_u[d] = gradients[i][d];
-                      material_inputs_cell.strain_rate[i] = symmetrize (grad_u);
-                    }
-
-                  // Evaluate the material model to get the reaction rates
-                  // for all the particles in the current cell.
-                  this->get_material_model().evaluate (material_inputs_cell,material_outputs_cell);
-
-                  // Update all particles in the current cell.
-                  particle = particles_in_cell.begin();
-                  for (unsigned int i = 0; particle!=particles_in_cell.end(); ++particle,++i)
-                    {
-                      // Add the reaction_rates * timestep = update to the corresponding stress
-                      // tensor components
-                      for (unsigned int p = 0; p < 2*SymmetricTensor<2,dim>::n_independent_components ; ++p)
-                        particle->get_properties()[data_position + p] = material_inputs_cell.composition[i][stress_field_indices[p]] + reaction_rate_outputs->reaction_rates[i][stress_field_indices[p]] * this->get_timestep();
-                    }
-                }
-            }
       }
 
 
@@ -309,6 +134,9 @@ namespace aspect
       ElasticStress<dim>::update_particle_properties(const ParticleUpdateInputs<dim> &inputs,
                                                      typename ParticleHandler<dim>::particle_iterator_range &particles) const
       {
+        const std::shared_ptr<MaterialModel::ReactionRateOutputs<dim>> reaction_rate_outputs
+          = material_outputs.template get_additional_output_object<MaterialModel::ReactionRateOutputs<dim>>();
+
         unsigned int p = 0;
         for (auto &particle: particles)
           {
@@ -338,9 +166,21 @@ namespace aspect
 
             this->get_material_model().evaluate (material_inputs,material_outputs);
 
-            // Apply the stress rotation to the ve_stress_* fields, not the ve_stress_*_old fields.
+            // Apply the stress rotation to the ve_stress_* fields, not the ve_stress_*_old fields
+            // and update the corresponding material model inputs as well.
             for (unsigned int i = 0; i < SymmetricTensor<2,dim>::n_independent_components ; ++i)
+            {
               particle.get_properties()[this->data_position + i] += material_outputs.reaction_terms[0][stress_field_indices[i]];
+              material_inputs.composition[0][stress_field_indices[i]] += material_outputs.reaction_terms[0][stress_field_indices[i]];
+            }
+
+            // Evaluate the material model again, this time with the rotated stresses
+            this->get_material_model().evaluate (material_inputs,material_outputs);
+
+            // Add the reaction_rates * timestep = update to the corresponding stress
+            // tensor components of current and old stresses.
+            for (unsigned int i = 0; i < 2*SymmetricTensor<2,dim>::n_independent_components ; ++i)
+              particle.get_properties()[this->data_position + i] += reaction_rate_outputs->reaction_rates[0][stress_field_indices[i]] * this->get_timestep();
 
             ++p;
           }


### PR DESCRIPTION
@anne-glerum I think I found a solution for the particles update. The first commit shows a conservative approach, where I introduce a new signal after the particle update that calls the additional update function of the elastic stress particle property. But when thinking about the time stepping more, I realized that that should be exactly equivalent to performing the operator splitting update immediately after the usual update, and in the same function. This would save us a lot of awkward code. I did test the viscous_relaxation benchmark with particles and it looked good (plotted error is identical to the figure in our manuscript).

What do you think? Does this look correct? Do you want to test it with one of the more complex benchmarks?

I also want to look into not requiring the old stresses if they are not needed as a follow-up, but that should only affect performance, not the results of the benchmarks.